### PR TITLE
Add scripts to build compilation db and run build cleaner

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 build --workspace_status_command="scripts/create-workspace-status.sh"
 
 # C++, with warnings mostly turned to 11.
-build       --cxxopt=-std=c++17            --host_cxxopt=-std=c++17
+build       --cxxopt=-std=c++20            --host_cxxopt=-std=c++20
 build       --cxxopt=-xc++                 --host_cxxopt=-xc++
 build       --cxxopt=-Wall                 --host_cxxopt=-Wall
 build       --cxxopt=-Wextra               --host_cxxopt=-Wextra
@@ -21,7 +21,7 @@ build --host_per_file_copt=external/.*@-w
 build --enable_platform_specific_config
 build:macos --macos_minimum_os=10.15
 build:macos --features=-supports_dynamic_linker
-build:macos --cxxopt=-std=c++17            --host_cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++20            --host_cxxopt=-std=c++20
 
 # Print out test log on failure.
 test --test_output=errors

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ MODULE.bazel.lock
 .env.production.local
 .direnv
 .envrc
-compile_commands.json
+compile_flags.txt
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,13 +27,5 @@ git_override(
     remote = "https://github.com/f4pga/prjxray.git",
 )
 
-# Repo to generate compilation database.
-bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-git_override(
-    module_name = "hedron_compile_commands",
-    commit = "4f28899228fb3ad0126897876f147ca15026151e",
-    patch_strip = 1,
-    # https://github.com/hedronvision/bazel-compile-commands-extractor/issues/199
-    patches = ["//bazel:bazel-compile-commands-extractor-fix.patch"],
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
-)
+# compilation DB; build_cleaner
+bazel_dep(name = "bant", version = "0.1.14", dev_dependency = True)

--- a/scripts/get-bant-path.sh
+++ b/scripts/get-bant-path.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Print path to a bant binary. Can be provided by an environment variable
+# or built from our dependency.
+
+BAZEL=${BAZEL:-bazel}
+BANT=${BANT:-needs-to-be-compiled-locally}
+
+# Bant not given, compile from bzlmod dep.
+if [ "${BANT}" = "needs-to-be-compiled-locally" ]; then
+  "${BAZEL}" build --noshow_progress -c opt @bant//bant:bant 2>/dev/null
+  BANT=$(realpath bazel-bin/external/bant*/bant/bant | head -1)
+fi
+
+echo $BANT

--- a/scripts/make-compilation-db.sh
+++ b/scripts/make-compilation-db.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -u
+set -e
+
+# Which bazel and bant to use. If unset, defaults are used.
+BAZEL=${BAZEL:-bazel}
+BANT=$($(dirname $0)/get-bant-path.sh)
+
+# Important to run with --remote_download_outputs=all to make sure generated
+# files are actually visible locally in case a remote cache (that includes
+# --disk_cache) is used ( https://github.com/hzeller/bazel-gen-file-issue )
+BAZEL_OPTS="-c opt --remote_download_outputs=all"
+
+# Tickle some build targets to fetch all dependencies and generate files,
+# so that they can be seen by the users of the compilation db.
+"${BAZEL}" build ${BAZEL_OPTS} @googletest//:has_absl @rapidjson
+
+# Create compilation DB. Command 'compilation-db' creates a huge *.json file,
+# but compile_flags.txt is perfectly sufficient and easier for tools to use.
+"${BANT}" compile-flags > compile_flags.txt
+
+# If there are two styles of comp-dbs, tools might have issues. Warn user.
+if [ -r compile_commands.json ]; then
+  echo -e "\n\033[1;31mSuggest to remove old compile_commands.json to not interfere with compile_flags.txt\033[0m\n"
+fi

--- a/scripts/run-build-cleaner.sh
+++ b/scripts/run-build-cleaner.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -u
+
+readonly BANT_EXIT_ON_DWYU_ISSUES=3
+
+# Which bazel and bant to use can be chosen by environment variables
+BAZEL=${BAZEL:-bazel}
+BANT=$($(dirname $0)/get-bant-path.sh)
+
+# Run depend-on-what-you-use build-cleaner.
+# Print buildifier commands to fix if needed.
+"${BANT}" dwyu "$@"
+
+BANT_EXIT=$?
+if [ ${BANT_EXIT} -eq ${BANT_EXIT_ON_DWYU_ISSUES} ]; then
+  cat >&2 <<EOF
+
+Build dependency issues found, the following one-liner will fix it. Amend PR.
+
+source <(scripts/run-build-cleaner.sh $@)
+EOF
+fi
+
+exit $BANT_EXIT


### PR DESCRIPTION
This uses http://bant.build/ which requires to be compiled with at least c++20, so changing minimum c++ requirements.

This adds two scripts
  * scripts/make-compilation-db.sh to build a compilation db, which is a compile_flags.txt
  * scripts/run-build-cleaner.sh that checks for missing or superfluous dependencies in the bazel BUILD rules.