### PR TITLE
Only run clang-format in files under fpga/

### DIFF
--- a/.github/bin/run-clang-format.sh
+++ b/.github/bin/run-clang-format.sh
@@ -11,9 +11,7 @@ ${CLANG_FORMAT} --version
 
 # Run on all files.
 
-find . -name "*.h" -o -name "*.cc" \
-  | egrep -v 'third_party/|external_libs/|.github/' \
-  | xargs -P2 ${CLANG_FORMAT} -i
+find fpga/ -name "*.h" -o -name "*.cc" | xargs -P2 ${CLANG_FORMAT} -i
 
 # If we have buildifier installed, use that on BUILD files
 if command -v ${BUILDIFIER} >/dev/null; then


### PR DESCRIPTION
... without, it might also affect the script directory, accidentally removing the +x bit from run-clang-tidy-cached.cc