### PR TITLE
Fixed double parsing of segbits

### DIFF
--- a/fpga/database.cc
+++ b/fpga/database.cc
@@ -398,23 +398,16 @@ void PartDatabase::ConfigBits(const std::string &tile_name,
     }
   }
 
-  const std::optional<SegmentsBitsWithPseudoPIPs> maybe_segment_bits =
-    tiles_->bits(tile_type);
-  if (!maybe_segment_bits.has_value()) return;
-  const SegmentsBitsWithPseudoPIPs &segment_bits = maybe_segment_bits.value();
-  const std::string tile_segments_bits_key =
-    absl::StrJoin({tile_name, aliased_feature}, ".");
-  if (segment_bits.pips.contains(tile_segments_bits_key)) {
-    return;
-  }
-
   // Fill the cache with the current tile type segbits.
   AddSegbitsToCache(tile_type);
-  if (!segment_bits_cache_.contains(tile_type)) {
-    return;
-  }
+  CHECK(segment_bits_cache_.contains(tile_type));
   const SegmentsBitsWithPseudoPIPs &tile_type_features_bits =
     segment_bits_cache_.at(tile_type);
+  const std::string tile_segments_bits_key =
+    absl::StrJoin({tile_name, aliased_feature}, ".");
+  if (tile_type_features_bits.pips.contains(tile_segments_bits_key)) {
+    return;
+  }
 
   // Search our database of features and get the segbit.
   const struct TileFeature tile_feature = {


### PR DESCRIPTION
Current logic was mistakenly parsing segbits files at each PartDatabase::ConfigBits() call instead of reusing cached deserialized values.
Code now is 10x faster than python version using xc7/counter_test generated fasm.
