### PR TITLE
Add the memory mapping header to the `hdrs=[]` attribute.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,4 +11,4 @@ bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20250205")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # compilation DB; build_cleaner
-bazel_dep(name = "bant", version = "0.2.4")
+bazel_dep(name = "bant", version = "0.3.3")

--- a/flake.nix
+++ b/flake.nix
@@ -96,8 +96,8 @@
                 registry = pkgs.fetchFromGitHub {
                   owner = "bazelbuild";
                   repo = "bazel-central-registry";
-                  rev = "5a6d227d0a69e6ab1dd5ad1cd82b9f61da633050";
-                  hash = "sha256-5ugohzWV/zMGhBfq0mHD3OdYluPHzjTOy4J1Xwhpjv4=";
+                  rev = "6873d34b26b6b294a80c7e4bd2cda1926fdfcc4d";
+                  hash = "sha256-iMjT8jar5x2JYl9OJoGrjljxtK0elwMsOYa1xnNVe6M=";
                 };
 
                 repoCache = pkgs.stdenv.mkDerivation {
@@ -115,7 +115,7 @@
                   # Trigger a build to get the new hash for the targeted repository cache
                   outputHash =
                     {
-                      x86_64-linux = "sha256-a1O4XNb/1dqMFKIbwrchqYTcvpZXqsv2wa4drkeFAJk=";
+                      x86_64-linux = "sha256-+m6lY9af3oZ4X5ZpcB8moql87YxbDJX1x5dYBwQjE8M=";
                     }
                     .${system} or (throw "No hash for system: ${system}");
 

--- a/fpga/BUILD
+++ b/fpga/BUILD
@@ -35,6 +35,8 @@ cc_library(
     name = "memory-mapped-file",
     srcs = [
         "memory-mapped-file.cc",
+    ],
+    hdrs = [
         "memory-mapped-file.h",
     ],
     deps = [
@@ -72,7 +74,6 @@ cc_test(
     ],
     deps = [
         ":database-parsers",
-        ":memory-mapped-file",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings:str_format",
@@ -100,7 +101,6 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",
-        "@rapidjson",
     ],
 )
 
@@ -129,7 +129,6 @@ cc_binary(
         ":database",
         ":database-parsers",
         ":fasm-parser",
-        ":memory-mapped-file",
         "//fpga/xilinx:arch-types",
         "//fpga/xilinx:bitstream",
         "@abseil-cpp//absl/cleanup:cleanup",

--- a/fpga/xilinx/BUILD
+++ b/fpga/xilinx/BUILD
@@ -259,6 +259,7 @@ cc_test(
         ":arch-types",
         ":bitstream-reader",
         "@abseil-cpp//absl/types:span",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )

--- a/fpga/xilinx/BUILD
+++ b/fpga/xilinx/BUILD
@@ -133,7 +133,6 @@ cc_library(
     deps = [
         ":arch-xc7-frame",
         "//fpga:database-parsers",
-        "//fpga:memory-mapped-file",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/status:statusor",

--- a/fpga/xilinx/bitstream-reader-xc7_test.cc
+++ b/fpga/xilinx/bitstream-reader-xc7_test.cc
@@ -7,14 +7,13 @@
  *
  * SPDX-License-Identifier: ISC
  */
-#include <gtest/gtest.h>
-
 #include <cstdint>
 #include <vector>
 
 #include "absl/types/span.h"
 #include "fpga/xilinx/arch-types.h"
 #include "fpga/xilinx/bitstream-reader.h"
+#include "gtest/gtest.h"
 
 namespace fpga {
 namespace xilinx {


### PR DESCRIPTION
Otherwise, it would be considered an internal header. After that change, now bant could remove dependencies in cases where it previously had seen an included header that it could not associate with any library and thus needed to be conservative in removing unused dependencies.