### PR TITLE
ci: run NixBuild (cachix) only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
       - run: |
           nix flake check
   NixBuild:
+    # Pushing to the cachix binary cache needs CACHIX_AUTH_TOKEN, which GitHub
+    # does not expose to pull requests from forks. Only build and push the
+    # cache on push/merge to main, never on external PRs.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      CACHIX_AUTH_TOKEN: "${{ secrets.CACHIX_AUTH_TOKEN }}"
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
@@ -94,10 +100,20 @@ jobs:
         with:
           name: fpga-assembler
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: |
+      - name: Build
+        run: |
+          nix build --no-link --print-out-paths
+      # Defensive: only push when a token is actually present. The job above
+      # already restricts this to push-to-main (where the secret exists), but
+      # this keeps the push steps safe if the trigger is ever widened.
+      - name: Push flake inputs to cachix
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        run: |
           nix flake archive --json \
             | jq -r '.path,(.inputs|to_entries[].value.path)' \
             | cachix push fpga-assembler
-      - run: |
+      - name: Push build output to cachix
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        run: |
           nix build --no-link --print-out-paths \
             | cachix push fpga-assembler


### PR DESCRIPTION
## Problem

`NixBuild` fails on every pull request opened from a fork (e.g. #34). The job dies at the `cachix push` step with:

```
Neither auth token nor signing key are present.
```

GitHub does not expose repository secrets to `pull_request` workflows triggered from forks, so `secrets.CACHIX_AUTH_TOKEN` is empty. The cachix cache can only be populated from trusted contexts.

## Fix

Gate the whole `NixBuild` job on `github.event_name == 'push'`, so it only builds and pushes the binary cache on push/merge to `main` — never on external PRs, where it cannot work anyway.

Defensively, the individual push steps are also guarded by `env.CACHIX_AUTH_TOKEN != ''` and `nix build` runs as its own step, so the flake is still validated and the push stays safe if the trigger is ever widened.

Only `.github/workflows/ci.yml` is touched. The `flake.nix` bant/registry issue surfaced separately on #34 and is handled there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)