### PR TITLE
ci: move cachix delivery to a dedicated cachix workflow

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,39 @@
+name: cachix
+on:
+  push:
+    branches:
+      - main
+  # Allow re-populating the cache manually, e.g. after fixing flake hashes.
+  workflow_dispatch:
+jobs:
+  CachixPush:
+    runs-on: ubuntu-latest
+    # Pushing to the cachix binary cache needs CACHIX_AUTH_TOKEN, which GitHub
+    # only exposes to trusted contexts like the triggers above, never to pull
+    # requests from forks. The job-level env makes the token visible to the
+    # step guards below, which keep the push steps safe if the triggers are
+    # ever widened.
+    env:
+      CACHIX_AUTH_TOKEN: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: fpga-assembler
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      # cachix-action pushes newly built store paths (including intermediate
+      # derivations such as the bazel repository cache) as they are built, so
+      # no explicit push of the build outputs is needed.
+      - name: Build
+        run: |
+          nix build --no-link --print-out-paths
+      # Flake inputs are substituted rather than built, so the post-build
+      # hooks above do not cover them; push them explicitly.
+      # https://docs.cachix.org/pushing#pushing-flake-inputs
+      - name: Push flake inputs to cachix
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        run: |
+          nix flake archive --json \
+            | jq -r '.path,(.inputs|to_entries[].value.path)' \
+            | cachix push fpga-assembler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Create Cache Timestamp
@@ -20,7 +20,7 @@ jobs:
         with:
           format: 'YYYY-MM-DD-HH-mm-ss'
       - name: Mount bazel cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: "~/.cache/bazel"
           key: bazelcache_test_${{ steps.cache_timestamp.outputs.time }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Test
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install Dependencies
@@ -59,7 +59,7 @@ jobs:
         with:
           format: 'YYYY-MM-DD-HH-mm-ss'
       - name: Mount clang-tidy cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/clang-tidy
@@ -74,46 +74,12 @@ jobs:
           clang-tidy-18 --version
           CLANG_TIDY=clang-tidy-18 scripts/run-clang-tidy-cached.cc \
             || ( cat fpga-assembler_clang-tidy.out ; exit 1)
+  # Building and pushing the nix package to the cachix binary cache happens
+  # in the cachix workflow, which only runs on push to main.
   NixCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
       - run: |
           nix flake check
-  NixBuild:
-    # Pushing to the cachix binary cache needs CACHIX_AUTH_TOKEN, which GitHub
-    # does not expose to pull requests from forks. Only build and push the
-    # cache on push/merge to main, never on external PRs.
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    env:
-      CACHIX_AUTH_TOKEN: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v15
-        with:
-          name: fpga-assembler
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - name: Build
-        run: |
-          nix build --no-link --print-out-paths
-      # Defensive: only push when a token is actually present. The job above
-      # already restricts this to push-to-main (where the secret exists), but
-      # this keeps the push steps safe if the trigger is ever widened.
-      - name: Push flake inputs to cachix
-        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
-        run: |
-          nix flake archive --json \
-            | jq -r '.path,(.inputs|to_entries[].value.path)' \
-            | cachix push fpga-assembler
-      - name: Push build output to cachix
-        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
-        run: |
-          nix build --no-link --print-out-paths \
-            | cachix push fpga-assembler


### PR DESCRIPTION
Restructures the cachix delivery per review discussion (supersedes the earlier ref-check-only version of this PR).

## `cachix.yml` (new): delivery as its own workflow

The build-and-push-to-cachix job moves out of `ci.yml` into a dedicated `cachix` workflow triggered only on **push to `main`** (plus `workflow_dispatch` for manually re-populating the cache). The fork-PR secrets problem is now solved structurally — the workflow can't trigger from a PR at all, so no job-level `if` gymnastics. The defensive `env.CACHIX_AUTH_TOKEN != ''` guard on the push step stays as a backstop.

## Redundancy fix

The old explicit `nix build | cachix push` step was redundant — and strictly weaker — than what cachix-action already does: its post-build hooks push **all** newly built store paths as they're built, including intermediates like the bazel repository cache (which the explicit push of the runtime closure never covered). Dropped. The explicit **flake-inputs** push stays: inputs are substituted, not built, so hooks can't see them ([official pattern](https://docs.cachix.org/pushing#pushing-flake-inputs)).

## Modernization

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v7 | node24/ESM; v7's fork-PR restriction only affects `pull_request_target`/`workflow_run` (unused here) |
| `actions/cache` | v4 | v6 | node24/ESM only |
| `cachix/install-nix-action` | v25 | v31 | |
| `cachix/cachix-action` | v15 | v17 | fixes the node20 deprecation warning |

Also dropped the unused `nix_path` input — every nix command in these workflows is flake-based.

Both files pass `actionlint` and the repo's `nix fmt` (yamlfmt).

Note: on PRs there is no NixBuild/skipped check anymore — the `cachix` workflow simply doesn't exist for that event. `NixCheck` (`nix flake check`) still runs on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)