### PR TITLE
xilinx: zero-initialize COR0 option value

### DIFF
--- a/fpga/xilinx/arch-xc7-configuration-packet.h
+++ b/fpga/xilinx/arch-xc7-configuration-packet.h
@@ -189,7 +189,7 @@ class ConfigurationOptions0Value {
   }
 
  private:
-  uint32_t value_;
+  uint32_t value_ = 0;
 };
 }  // namespace xc7
 }  // namespace xilinx


### PR DESCRIPTION
Fixes #41.

Default-initialize the backing COR0 word so every `ConfigurationOptions0Value` starts from deterministic zero bits.

The existing value-initialized call site remains unchanged, while future default-initialized instances can no longer expose indeterminate untouched bits through the setters read-modify-write operations.

## Testing

- `git diff --check`
- `/opt/homebrew/opt/llvm/bin/clang-format --dry-run --Werror fpga/xilinx/arch-xc7-configuration-packet.h`

Bazel and Nix are not installed in the local environment. The exact base commit has passing upstream Test, MacOsBuild, ClangTidy, NixCheck, and Cachix jobs.

Prepared with Codex assistance.